### PR TITLE
Switched tinker-dash to use Firefox w/ GeckoDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ unzip -a chromedriver-v1.8.0-linux-arm.zip
 
 export PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/home/linaro/bin"
 ```
+
+An additional step is required to install the gecko driver for Firefox:
+```
+/bin/bash set-up.sh <OS Type>
+```
+
 ### Usage
 
 #### Cloud content synchronisation across multiple ARM devices

--- a/set-up.sh
+++ b/set-up.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+if [ $# -ne 1 ]; then
+	echo "Which OS are you setting up for?
+Options are:
+--> mac
+--> tinker
+Please type answer:"
+
+	read OS
+else
+	OS=$1
+fi
+
+if [ "$OS" == "tinker" ]; then
+	echo "Setting up geckodriver for tinker OS"
+	echo https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-arm7hf.tar.gz
+	wget https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-arm7hf.tar.gz -O ./geckodriver-macos.tar.gz
+	gunzip geckodriver-macos.tar.gz
+	tar -xf geckodriver-macos.tar
+	sudo mv geckodriver /usr/bin/
+elif [ "$OS" == "mac" ]; then
+	echo "Setting up geckodriver for Mac OS"
+	echo https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-macos.tar.gz
+	rm -f ~/Downloads/geckodriver-macos.tar*
+	wget https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-macos.tar.gz -O ~/Downloads/geckodriver-macos.tar.gz
+	pushd ~/Downloads
+	gunzip geckodriver-macos.tar.gz
+	tar -xf geckodriver-macos.tar
+	sudo mv geckodriver /usr/bin/
+	popd
+else
+	echo "OS $OS is not supported"
+fi

--- a/tinker-dash.py
+++ b/tinker-dash.py
@@ -1,6 +1,5 @@
 import time
 from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 
 DASHBOARD_LIST = 'the-dashboard-list.txt'
 TAB_ROTATION_PERIOD = 15  # 15 second tab rotation
@@ -42,9 +41,7 @@ def rotate_dashboard(url_list, driver):
 
 
 def main():
-    chrome_options = Options()
-    chrome_options.add_argument("--disable-infobars")
-    browser = webdriver.Chrome('chromedriver', chrome_options=chrome_options)
+    browser = webdriver.Firefox()
 
     dashboard_list = pull_list(DASHBOARD_LIST)
     # The first browser tab is not in the tab rotation sequence (it is just a placeholder)


### PR DESCRIPTION
# Subject: Switched from Chrome to Firefox

--> I've added a set-up script to assist with installing geckodriver executable.
--> I've added this set-up into the README.md file
--> I've updated the python code to make use of the geckodriver
--> I've tested it locally using the Mac OS set-up and run guide.

## Collaborators
@anthonyblanchflower --> thanks for the help!

## Reference
 - Resolves: #1 